### PR TITLE
18: Added a Command Pallet

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -42,6 +42,7 @@ export function addData( vertices, face_indices ) {
 	geometry.computeVertexNormals();
 
 	const mesh = new THREE.Mesh( geometry, mesh_material );
+	// set the mesh to be drawn last so it is above the transparent vertices
 	mesh.renderOrder = -1
 	// Clear the scene of all but the initial children
 	clearMesh();

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -23,6 +23,11 @@ controls.addEventListener( 'change', function () {
 } );
 controls.update();
 
+// Materials
+const mesh_material = new THREE.MeshNormalMaterial( { transparent: true } );
+const vertex_material = new THREE.MeshBasicMaterial( { color: 0x000000, transparent: true } );
+setVertexOpacity(0);
+
 window.addEventListener( 'resize', onWindowResize );
 const num_initial_children = scene.children.length
 animate();
@@ -36,44 +41,64 @@ export function addData( vertices, face_indices ) {
 	geometry.setIndex( face_indices );
 	geometry.computeVertexNormals();
 
-	const material = new THREE.MeshNormalMaterial();
-	const mesh = new THREE.Mesh( geometry, material );
+	const mesh = new THREE.Mesh( geometry, mesh_material );
+	mesh.renderOrder = -1
 	// Clear the scene of all but the initial children
-	clear_mesh();
+	clearMesh();
 	scene.add( mesh );
+
+	addVertexMarkers( vertices );
 
 	render()
 }
 
-function clear_mesh() {
+function clearMesh() {
 	while(scene.children.length > num_initial_children){
 		scene.remove(scene.children[num_initial_children]);
 	}
 }
 
-function onWindowResize() {
+function addVertexMarkers( vertices ) {
+	// Vertices is a flat list of coordinates in the order [x1, y1, z1, x2, y2, z2, ...]
+	for (let i = 0; i < vertices.length; i += 3) {
+		const x = vertices[i];
+		const y = vertices[i + 1];
+		const z = vertices[i + 2];
 
+		const sphereGeometry = new THREE.SphereGeometry(0.05, 6, 4);
+		sphereGeometry.computeVertexNormals();
+		sphereGeometry.translate(x, y, z)
+		const vertex = new THREE.Mesh( sphereGeometry, vertex_material );
+		scene.add( vertex );
+
+	}
+}
+
+export function setMeshOpacity( value ) {
+	mesh_material.opacity = value;
+	render();
+}
+
+export function setVertexOpacity( value ) {
+	vertex_material.opacity = value;
+	render();
+}
+
+function onWindowResize() {
 	camera.aspect = window.innerWidth / window.innerHeight;
 	camera.updateProjectionMatrix();
 
 	controls.handleResize();
 
 	renderer.setSize( window.innerWidth, window.innerHeight );
-
 }
 
 function animate() {
-
 	requestAnimationFrame( animate );
-
 	controls.update(); // only required if controls.enableDamping = true, or if controls.autoRotate = true
-
 	render();
-
 }
 
 function render() {
-
 	renderer.render( scene, camera );
-
 }

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -39,12 +39,16 @@ export function addData( vertices, face_indices ) {
 	const material = new THREE.MeshNormalMaterial();
 	const mesh = new THREE.Mesh( geometry, material );
 	// Clear the scene of all but the initial children
-	while(scene.children.length > num_initial_children){
-		scene.remove(scene.children[num_initial_children]);
-	}
+	clear_mesh();
 	scene.add( mesh );
 
 	render()
+}
+
+function clear_mesh() {
+	while(scene.children.length > num_initial_children){
+		scene.remove(scene.children[num_initial_children]);
+	}
 }
 
 function onWindowResize() {

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -48,7 +48,7 @@ export function addData( vertices, face_indices ) {
 	clearMesh();
 	scene.add( mesh );
 
-	addVertexMarkers( vertices );
+	// addVertexMarkers( vertices );
 
 	render()
 }
@@ -59,19 +59,25 @@ function clearMesh() {
 	}
 }
 
-function addVertexMarkers( vertices ) {
+export function addVertexMarkers( vertices ) {
 	// Vertices is a flat list of coordinates in the order [x1, y1, z1, x2, y2, z2, ...]
 	for (let i = 0; i < vertices.length; i += 3) {
 		const x = vertices[i];
 		const y = vertices[i + 1];
 		const z = vertices[i + 2];
 
-		const sphereGeometry = new THREE.SphereGeometry(0.05, 6, 4);
+		const sphereGeometry = new THREE.SphereGeometry(0.25, 6, 4);
 		sphereGeometry.computeVertexNormals();
 		sphereGeometry.translate(x, y, z)
 		const vertex = new THREE.Mesh( sphereGeometry, vertex_material );
 		scene.add( vertex );
 
+	}
+}
+
+export function removeVertexMarkers() {
+	while(scene.children.length > num_initial_children + 1){
+		scene.remove(scene.children[num_initial_children + 1]);
 	}
 }
 

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { ArcballControls } from 'three/addons/controls/ArcballControls.js';
 
-const width = window.innerWidth, height = window.innerHeight;
+const width = parent.innerWidth * 0.78, height = parent.innerHeight * 0.9;
 
 // init
 

--- a/vis/api_viewsets.py
+++ b/vis/api_viewsets.py
@@ -96,3 +96,19 @@ def clear_mesh(request):
     settings.GLOBAL_MESH = None
     send_new_global_mesh()
     return Response("Mesh cleared", status=200)
+
+
+@api_view(["GET"])
+@permission_classes((permissions.AllowAny,))
+def get_density_map(request):
+    if settings.GLOBAL_MESH is not None:
+        return JsonResponse(
+            {"message": "data enclosed", "data": settings.GLOBAL_MESH.htlm_density_map},
+            status=200
+        )
+    else:
+        map_size = ThreeDimensionalMesh.density_map_size()
+        return JsonResponse(
+            {"message": "no global mesh", "data": [[False] * map_size] * map_size},
+            status=201
+        )

--- a/vis/api_viewsets.py
+++ b/vis/api_viewsets.py
@@ -9,6 +9,7 @@ from django.http.response import JsonResponse
 from logging import getLogger
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework import permissions
+from rest_framework.response import Response
 
 from .models import ThreeDimensionalMesh
 
@@ -21,10 +22,16 @@ channel_layer = get_channel_layer()
 
 
 def send_new_global_mesh():
-    content = {
-        "flat_vertices": settings.GLOBAL_MESH.get_flat_vertices().tolist(),
-        "flat_faces": settings.GLOBAL_MESH.get_flat_faces().tolist(),
-    }
+    if settings.GLOBAL_MESH is None:
+        content = {
+            "flat_vertices": [],
+            "flat_faces": [],
+        }
+    else:
+        content = {
+            "flat_vertices": settings.GLOBAL_MESH.get_flat_vertices().tolist(),
+            "flat_faces": settings.GLOBAL_MESH.get_flat_faces().tolist(),
+        }
     async_to_sync(channel_layer.group_send)("global", {"type": "new_data", "content": content})
 
 
@@ -81,3 +88,11 @@ def add_point_to_mesh(request):
     except Exception as e:
         logger.error(e)
         return JsonResponse({"message": "An error occurred."}, status=500)
+
+
+@api_view(["DELETE"])
+@permission_classes((permissions.AllowAny,))
+def clear_mesh(request):
+    settings.GLOBAL_MESH = None
+    send_new_global_mesh()
+    return Response("Mesh cleared", status=200)

--- a/vis/models.py
+++ b/vis/models.py
@@ -26,6 +26,9 @@ class ThreeDimensionalMesh(Delaunay):
             *args,
             **kwargs)
 
+        # Showing the density of information
+        self.density_map = np.asarray([[0] * 256] * 256, dtype=np.uint8)
+
     @classmethod
     def load_from_file(cls, file_name: str, *args, **kwargs):
         """

--- a/vis/models.py
+++ b/vis/models.py
@@ -1,3 +1,5 @@
+import math
+
 from numpy.typing import NDArray
 from scipy.spatial import Delaunay
 import numpy as np
@@ -27,7 +29,15 @@ class ThreeDimensionalMesh(Delaunay):
             **kwargs)
 
         # Showing the density of information
-        self.density_map = np.asarray([[0] * 256] * 256, dtype=np.uint8)
+        self.density_map = np.asarray([[False] * self.density_map_size()] * self.density_map_size(), dtype=bool)
+        self.min_x = -10
+        self.max_x = 10
+        self.min_y = -10
+        self.max_y = 10
+
+    @staticmethod
+    def density_map_size() -> int:
+        return 64
 
     @classmethod
     def load_from_file(cls, file_name: str, *args, **kwargs):
@@ -66,6 +76,23 @@ class ThreeDimensionalMesh(Delaunay):
         """
         return self.simplices
 
+    @property
+    def htlm_density_map(self):
+        """
+
+        Returns:
+
+        """
+        size = self.density_map_size()
+        img = np.asarray([[False] * size] * size, dtype=bool)
+
+        for x, y in self.points:
+            x_idx = int((x - self.min_x) / (self.max_x - self.min_x) * (size - 1))
+            y_idx = int((y - self.min_y) / (self.max_y - self.min_y) * (size - 1))
+            img[x_idx][y_idx] = True
+
+        return img.tolist()
+
     def get_flat_vertices(self) -> NDArray:
         """
         The vectorized form of the vertices
@@ -97,3 +124,20 @@ class ThreeDimensionalMesh(Delaunay):
         z = vertices[:, 2]
         self.z = np.concatenate((self.z, z))
         self.add_points(x_and_y, *args, **kwargs)
+        for x, y in x_and_y:
+            self.update_min_and_max(x, y)
+
+    def update_min_and_max(self, x, y):
+        """
+
+        Args:
+            x:
+            y:
+
+        Returns:
+
+        """
+        self.min_x = min(x, self.min_x)
+        self.max_x = max(x, self.max_x)
+        self.min_y = min(y, self.min_y)
+        self.max_y = max(y, self.max_y)

--- a/vis/models.py
+++ b/vis/models.py
@@ -1,5 +1,3 @@
-import math
-
 from numpy.typing import NDArray
 from scipy.spatial import Delaunay
 import numpy as np

--- a/vis/templates/vis/dynamic.html
+++ b/vis/templates/vis/dynamic.html
@@ -26,6 +26,18 @@
           display: table;
           clear: both;
         }
+
+        .density_map_filled{
+            background-color: black;
+            width: 1px;
+            height: 1px;
+        }
+
+        .density_map_empty{
+            background-color: white;
+            width: 1px;
+            height: 1px;
+        }
     </style>
     <head>
         {% render_bundle 'main' %}
@@ -37,8 +49,10 @@
         <div id="body" class="row">
             <div id="render-region" class="render-region" style="width: 80%"></div>
             <div id="command-panel" class="command-panel" style="width: 19%">
-                <h1>Hellow there</h1>
+                <h1>Command Pallet</h1>
+                <h3>Mesh Functionality</h3>
                 <button onclick="clear_global_mesh()">Clear Mesh</button>
+                <button onclick="get_density_map()">Update Density Map</button>
                 <div>
                     <input type="range" id="mesh_opacity" name="mesh_opacity" min="0" max="1" step="0.01" value="1">
                     <label for="mesh_opacity">Mesh Opacity</label>
@@ -47,6 +61,8 @@
                     <input type="range" id="vertex_opacity" name="vertex_opacity" min="0" max="1" step="0.01" value="0">
                     <label for="vertex_opacity">Vertex Opacity</label>
                 </div>
+                <h3>Density Map</h3>
+                <table id="density_map" style="border: 1px solid;"></table>
                 <br>
                 <p id="status-message"></p>
             </div>
@@ -63,24 +79,61 @@
 
         meshSocket.onmessage = function(e) {
             const data = JSON.parse(e.data);
-            vis.addData( data.flat_vertices, data.flat_faces ) ;
+            vis.addData( data.flat_vertices, data.flat_faces );
         };
 
         meshSocket.onclose = function(e) {
             console.error('Chat socket closed unexpectedly');
         };
 
+        // page functionality
+        const emptyDensityRow = Array(64)
+        emptyDensityRow.fill(false)
+        const emptyDensityMap = Array(64)
+        emptyDensityMap.fill(emptyDensityRow)
+
         window.onload = function () {
-            vis.addData( {{ flat_vertices }}, {{ flat_faces }} ) ;
+            vis.addData( {{ flat_vertices }}, {{ flat_faces }} );
+            updateDensityMap( emptyDensityMap );
           };
+
+        function updateDensityMap( densityArray ) {
+            // clear the density map
+            const mapObject = document.querySelector("#density_map");
+            mapObject.innerHTML = "";
+            // set the inner content
+            densityArray.forEach((rowVal, i) => {
+                const rowObj = mapObject.insertRow(i);
+                rowVal.forEach((colVal, j) => {
+                    const cellObj = rowObj.insertCell(j);
+                    if (colVal) {
+                        cellObj.className = "density_map_filled";
+                    } else {
+                        cellObj.className = "density_map_empty";
+                    }
+                });
+            });
+        }
 
         // Button interactions
         function clear_global_mesh() {
-            fetch("{{ BASE_URL }}/api/mesh/clear/", {method: 'DELETE'})
+            fetch("/api/mesh/clear/", {method: 'DELETE'})
                 .then(response => {
                         document.getElementById("status-message").innerText = "mesh cleared"
                     }
                 )
+        }
+
+        function get_density_map() {
+            fetch('api/mehs/densitymap/')
+                .then(response => {
+                    response.json().then(
+                        dataObj => {
+                            console.log(dataObj.message);
+                            updateDensityMap(dataObj.data)
+                        }
+                    )
+                })
         }
 
         // Object opacity

--- a/vis/templates/vis/dynamic.html
+++ b/vis/templates/vis/dynamic.html
@@ -39,6 +39,14 @@
             <div id="command-panel" class="command-panel" style="width: 19%">
                 <h1>Hellow there</h1>
                 <button onclick="clear_global_mesh()">Clear Mesh</button>
+                <div>
+                    <input type="range" id="mesh_opacity" name="mesh_opacity" min="0" max="1" step="0.01" value="1">
+                    <label for="mesh_opacity">Mesh Opacity</label>
+                </div>
+                <div>
+                    <input type="range" id="vertex_opacity" name="vertex_opacity" min="0" max="1" step="0.01" value="0">
+                    <label for="vertex_opacity">Vertex Opacity</label>
+                </div>
                 <br>
                 <p id="status-message"></p>
             </div>
@@ -46,6 +54,7 @@
     </body>
 
     <script>
+        // Websockets
         const meshSocket = new WebSocket(
             'ws://'
             + window.location.host
@@ -65,6 +74,7 @@
             vis.addData( {{ flat_vertices }}, {{ flat_faces }} ) ;
           };
 
+        // Button interactions
         function clear_global_mesh() {
             fetch("{{ BASE_URL }}/api/mesh/clear/", {method: 'DELETE'})
                 .then(response => {
@@ -72,5 +82,17 @@
                     }
                 )
         }
+
+        // Object opacity
+        const meshOpacity = document.querySelector("#mesh_opacity");
+        meshOpacity.addEventListener("input", (event) => {
+            vis.setMeshOpacity(event.target.value);
+        });
+
+        const vertexOpacity = document.querySelector("#vertex_opacity");
+        vertexOpacity.addEventListener("input", (event) => {
+            vis.setVertexOpacity(event.target.value);
+        });
+
     </script>
 </html>

--- a/vis/templates/vis/dynamic.html
+++ b/vis/templates/vis/dynamic.html
@@ -38,6 +38,9 @@
             <div id="render-region" class="render-region" style="width: 80%"></div>
             <div id="command-panel" class="command-panel" style="width: 19%">
                 <h1>Hellow there</h1>
+                <button onclick="clear_global_mesh()">Clear Mesh</button>
+                <br>
+                <p id="status-message"></p>
             </div>
         </div>
     </body>
@@ -61,5 +64,13 @@
         window.onload = function () {
             vis.addData( {{ flat_vertices }}, {{ flat_faces }} ) ;
           };
+
+        function clear_global_mesh() {
+            fetch("{{ BASE_URL }}/api/mesh/clear/", {method: 'DELETE'})
+                .then(response => {
+                        document.getElementById("status-message").innerText = "mesh cleared"
+                    }
+                )
+        }
     </script>
 </html>

--- a/vis/templates/vis/dynamic.html
+++ b/vis/templates/vis/dynamic.html
@@ -53,6 +53,8 @@
                 <h3>Mesh Functionality</h3>
                 <button onclick="clear_global_mesh()">Clear Mesh</button>
                 <button onclick="get_density_map()">Update Density Map</button>
+                <button onclick="draw_vertices()">Draw vertices</button>
+                <button onclick="removeVertexMarkers()">Delete vertices</button>
                 <div>
                     <input type="range" id="mesh_opacity" name="mesh_opacity" min="0" max="1" step="0.01" value="1">
                     <label for="mesh_opacity">Mesh Opacity</label>
@@ -70,6 +72,8 @@
     </body>
 
     <script>
+        var savedVertices = [];
+
         // Websockets
         const meshSocket = new WebSocket(
             'ws://'
@@ -79,6 +83,7 @@
 
         meshSocket.onmessage = function(e) {
             const data = JSON.parse(e.data);
+            savedVertices = data.flat_vertices;
             vis.addData( data.flat_vertices, data.flat_faces );
         };
 
@@ -93,6 +98,7 @@
         emptyDensityMap.fill(emptyDensityRow)
 
         window.onload = function () {
+            savedVertices = {{ flat_vertices }};
             vis.addData( {{ flat_vertices }}, {{ flat_faces }} );
             updateDensityMap( emptyDensityMap );
           };
@@ -134,6 +140,14 @@
                         }
                     )
                 })
+        }
+
+        function draw_vertices() {
+            vis.addVertexMarkers( savedVertices );
+        }
+
+        function removeVertexMarkers() {
+            vis.removeVertexMarkers();
         }
 
         // Object opacity

--- a/vis/templates/vis/dynamic.html
+++ b/vis/templates/vis/dynamic.html
@@ -2,12 +2,44 @@
 <!DOCTYPE html>
 
 <html>
+    <style>
+        * {
+          box-sizing: border-box;
+        }
+
+        /* Create two equal columns that floats next to each other */
+        .render-region {
+            float: left;
+            width: 80%;
+            height: 90%;
+        }
+        .command-panel {
+            float: left;
+            width: 15%;
+            height: 90%;
+            padding: 10px;
+        }
+
+        /* Clear floats after the columns */
+        .row:after {
+          content: "";
+          display: table;
+          clear: both;
+        }
+    </style>
     <head>
         {% render_bundle 'main' %}
     </head>
     <body>
-        <h1>Here is not a cube</h1>
-        <div id="render-region"></div>
+        <div id="header">
+            <h1>Sampled Mesh</h1>
+        </div>
+        <div id="body" class="row">
+            <div id="render-region" class="render-region" style="width: 80%"></div>
+            <div id="command-panel" class="command-panel" style="width: 19%">
+                <h1>Hellow there</h1>
+            </div>
+        </div>
     </body>
 
     <script>

--- a/vis/urls.py
+++ b/vis/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     # API routes
     path('api/mesh/add_point/', api_viewsets.add_point_to_mesh, name="add point"),
     path('api/mesh/clear/', api_viewsets.clear_mesh, name="clear global mesh"),
+    path('api/mehs/densitymap/', api_viewsets.get_density_map, name="get density map"),
     # UI routes
     path('<path:file_name>/', views.mesh_from_file, name="file"),
     path('', views.mesh_dynamic, name="dynamic"),

--- a/vis/urls.py
+++ b/vis/urls.py
@@ -6,6 +6,7 @@ from . import api_viewsets
 urlpatterns = [
     # API routes
     path('api/mesh/add_point/', api_viewsets.add_point_to_mesh, name="add point"),
+    path('api/mesh/clear/', api_viewsets.clear_mesh, name="clear global mesh"),
     # UI routes
     path('<path:file_name>/', views.mesh_from_file, name="file"),
     path('', views.mesh_dynamic, name="dynamic"),


### PR DESCRIPTION
- Added a command pallet with the following functionalities:
  - Opacity of the mesh
  - Opacity of the vertices
  - Draw vertices
  - Delete vertices
  - Get a density map of the current sampling
  - Clear the mesh to allow for re-sampling without re-starting the application.
- Added the ability to draw vertex shapes 

![image](https://github.com/matthew-buglass/bathymetric_visualizer/assets/60230689/5935d48d-adad-47e9-810d-b3bafc76abc6)

Note the vertices are currently not being drawn, but they are small black circles.

Closes #18 